### PR TITLE
Add nix-dev Coder workspace template

### DIFF
--- a/coder-templates/nix-dev/README.md
+++ b/coder-templates/nix-dev/README.md
@@ -1,0 +1,29 @@
+# nix-dev Coder workspace template
+
+Runs `ghcr.io/graytonio/nixos-workspace` (built from
+[graytonio/nixos-config](https://github.com/graytonio/nixos-config),
+`coder/Dockerfile`) as a Kubernetes Pod in the `coder` namespace, with a
+Longhorn-backed PersistentVolumeClaim mounted at `/home/coder` that survives
+workspace stop/start.
+
+This directory is **not** ArgoCD-managed — Coder has no GitOps-native way to
+sync templates from git without enterprise features, so pushing it is a
+manual step.
+
+## Push this template
+
+```bash
+coder login https://coder.graytonward.com
+coder templates push nix-dev -d coder-templates/nix-dev/
+```
+
+Re-run `coder templates push` whenever this directory or the
+`nixos-workspace` image tag changes.
+
+## Prerequisites
+
+The `ghcr.io/graytonio/nixos-workspace:latest` image must exist before
+creating a workspace from this template — see the `nixos-config` repo's
+`coder-workspace-image` GitHub Actions workflow. Pushing this template
+without the image existing will succeed, but the first workspace creation
+will fail with `ImagePullBackOff`.

--- a/coder-templates/nix-dev/main.tf
+++ b/coder-templates/nix-dev/main.tf
@@ -40,14 +40,18 @@ locals {
 resource "coder_agent" "main" {
   os   = "linux"
   arch = "amd64"
-  dir  = "/home/coder"
 }
 
 # No `count` here -- this must persist across workspace stop/start, unlike
 # the pod below.
-resource "kubernetes_persistent_volume_claim" "home" {
+#
+# Named using the workspace's stable `id` (not `name`) so renaming the
+# workspace doesn't orphan this PVC -- Terraform would otherwise see the
+# name change as "create a new resource" and lose track of the old one
+# and its data.
+resource "kubernetes_persistent_volume_claim_v1" "home" {
   metadata {
-    name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}-home"
+    name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.id}-home"
     namespace = "coder"
   }
   spec {
@@ -64,7 +68,14 @@ resource "kubernetes_persistent_volume_claim" "home" {
 # start_count is 0 when the workspace is stopped and 1 when running -- this
 # is what makes Coder's stop/start actually delete/recreate the pod while
 # the PVC above stays put.
-resource "kubernetes_pod" "main" {
+#
+# A bare Pod (not a Deployment) is a deliberate choice: container-level
+# restart-on-crash still works via kubelet's default restartPolicy=Always,
+# and stop/start already works via the count toggle below. The trade-off is
+# no pod-level self-healing if the node itself reboots/evicts this pod --
+# acceptable for a single-user homelab where that's noticed quickly, but
+# worth knowing if this ever needs hands-off reliability.
+resource "kubernetes_pod_v1" "main" {
   count = data.coder_workspace.me.start_count
   metadata {
     name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
@@ -90,7 +101,7 @@ resource "kubernetes_pod" "main" {
     volume {
       name = "home"
       persistent_volume_claim {
-        claim_name = kubernetes_persistent_volume_claim.home.metadata[0].name
+        claim_name = kubernetes_persistent_volume_claim_v1.home.metadata[0].name
       }
     }
   }

--- a/coder-templates/nix-dev/main.tf
+++ b/coder-templates/nix-dev/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = ">= 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}
+
+provider "coder" {}
+
+# config_path = null triggers in-cluster auto-auth -- Terraform runs inside
+# the coder-production pod itself, using the coder ServiceAccount, which
+# already has full CRUD on pods/persistentvolumeclaims in this namespace
+# (chart default serviceAccount.workspacePerms: true).
+provider "kubernetes" {
+  config_path = null
+}
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+locals {
+  # home-manager's activation writes ~/.nix-profile/etc/profile.d/hm-session-vars.sh,
+  # which sets NIX_SSL_CERT_FILE/SSL_CERT_FILE (TLS trust for nix-built git/kubectl/etc,
+  # since nix binaries don't trust the base image's system CA store by default) and
+  # LOCALE_ARCHIVE (glibc locale data for fish/starship/nvim). These paths are
+  # content-addressed Nix store paths that change on every flake.lock update in the
+  # nixos-config repo, so they can't be hardcoded as static image ENV vars -- source
+  # the script dynamically here instead, right before starting the Coder agent, so
+  # the agent (and everything it spawns: terminal sessions, SSH sessions) inherits a
+  # correctly-configured environment regardless of which image build is running.
+  agent_start_script = "[ -f $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh ] && . $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh; ${coder_agent.main.init_script}"
+}
+
+resource "coder_agent" "main" {
+  os   = "linux"
+  arch = "amd64"
+  dir  = "/home/coder"
+}
+
+# No `count` here -- this must persist across workspace stop/start, unlike
+# the pod below.
+resource "kubernetes_persistent_volume_claim" "home" {
+  metadata {
+    name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}-home"
+    namespace = "coder"
+  }
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "longhorn"
+    resources {
+      requests = {
+        storage = "20Gi"
+      }
+    }
+  }
+}
+
+# start_count is 0 when the workspace is stopped and 1 when running -- this
+# is what makes Coder's stop/start actually delete/recreate the pod while
+# the PVC above stays put.
+resource "kubernetes_pod" "main" {
+  count = data.coder_workspace.me.start_count
+  metadata {
+    name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
+    namespace = "coder"
+  }
+  spec {
+    container {
+      name    = "dev"
+      image   = "ghcr.io/graytonio/nixos-workspace:latest"
+      command = ["sh", "-c", local.agent_start_script]
+
+      env {
+        name  = "CODER_AGENT_TOKEN"
+        value = coder_agent.main.token
+      }
+
+      volume_mount {
+        mount_path = "/home/coder"
+        name       = "home"
+      }
+    }
+
+    volume {
+      name = "home"
+      persistent_volume_claim {
+        claim_name = kubernetes_persistent_volume_claim.home.metadata[0].name
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds coder-templates/nix-dev/, a Terraform workspace template that runs
  ghcr.io/graytonio/nixos-workspace as a Pod in the coder namespace with a
  persistent /home/coder PVC
- Not ArgoCD-managed; coder-templates/nix-dev/README.md documents the
  `coder templates push` step

Depends on the nixos-config PR (workspace image build,
https://github.com/graytonio/nixos-config/pull/2) being merged and its CI
run completing before the template can actually be pushed/tested against a
real image.

Design spec: docs/superpowers/specs/2026-08-21-nix-coder-workspace-design.md

## Test plan
- [x] `terraform fmt -check` / `terraform validate` pass
- [ ] `coder templates push nix-dev -d coder-templates/nix-dev/` succeeds
- [ ] Test workspace creation succeeds, agent shows Connected, `coder config-ssh` + `ssh` works
- [ ] `/home/coder` survives a stop/start cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)