### PR TITLE
Add Coder template auto-sync CronJob

### DIFF
--- a/apps/coder/templates/template-sync-cronjob.yaml
+++ b/apps/coder/templates/template-sync-cronjob.yaml
@@ -12,10 +12,14 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["coder-template-sync-state"]
+    verbs: ["get", "patch"]
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
-    verbs: ["get", "create", "patch", "delete"]
+    verbs: ["get", "create", "patch", "delete", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -44,7 +48,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 900
       template:
         spec:
           serviceAccountName: coder-template-sync
@@ -54,7 +58,7 @@ spec:
               image: alpine/k8s:1.36.2
               command: ["/bin/sh", "/scripts/sync.sh"]
               env:
-                - name: CODER_TOKEN
+                - name: CODER_SESSION_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: coder-template-sync-token

--- a/apps/coder/templates/template-sync-cronjob.yaml
+++ b/apps/coder/templates/template-sync-cronjob.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coder-template-sync
+  namespace: coder
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coder-template-sync
+  namespace: coder
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "create", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coder-template-sync
+  namespace: coder
+subjects:
+  - kind: ServiceAccount
+    name: coder-template-sync
+    namespace: coder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coder-template-sync
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: coder-template-sync
+  namespace: coder
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: coder-template-sync
+          restartPolicy: Never
+          containers:
+            - name: sync
+              image: alpine/k8s:1.36.2
+              command: ["/bin/sh", "/scripts/sync.sh"]
+              env:
+                - name: CODER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: coder-template-sync-token
+                      key: token
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+          volumes:
+            - name: script
+              configMap:
+                name: coder-template-sync-script
+                defaultMode: 0755

--- a/apps/coder/templates/template-sync-script.yaml
+++ b/apps/coder/templates/template-sync-script.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coder-template-sync-script
+  namespace: coder
+data:
+  sync.sh: |
+    #!/bin/sh
+    set -eu
+
+    REPO_URL="https://github.com/graytonio/homelab-flagops-templates.git"
+    STATE_CONFIGMAP="coder-template-sync-state"
+    NAMESPACE="coder"
+    CODER_URL="http://coder.coder.svc.cluster.local"
+    PREPULL_DAEMONSET="coder-template-image-prepull"
+
+    WORKDIR=$(mktemp -d)
+    git clone --depth 50 --quiet "$REPO_URL" "$WORKDIR/repo"
+    cd "$WORKDIR/repo"
+
+    kubectl get configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" >/dev/null 2>&1 || \
+      kubectl create configmap "$STATE_CONFIGMAP" -n "$NAMESPACE"
+
+    # Pre-pull the workspace image on every node before anyone tries to
+    # create a workspace with it. Runs unconditionally, decoupled from the
+    # per-template push loop below -- must fire even when only the image
+    # digest changed and no template text did.
+    current_image=$(grep -oE 'image\s*=\s*"[^"]+nixos-workspace[^"]+"' coder-templates/nix-dev/main.tf | sed -E 's/image\s*=\s*"([^"]+)"/\1/' | head -1)
+    last_image=$(kubectl get configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" \
+      -o jsonpath='{.data.prepulled_image}' 2>/dev/null || true)
+
+    if [ -n "$current_image" ] && [ "$current_image" != "$last_image" ]; then
+      echo "Image changed ($last_image -> $current_image), pre-pulling on all nodes"
+      cat <<EOF | kubectl apply -f -
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: $PREPULL_DAEMONSET
+      namespace: $NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app: $PREPULL_DAEMONSET
+      template:
+        metadata:
+          labels:
+            app: $PREPULL_DAEMONSET
+        spec:
+          terminationGracePeriodSeconds: 0
+          containers:
+            - name: prepull
+              image: $current_image
+              command: ["sh", "-c", "sleep 3600"]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+    EOF
+      kubectl rollout status daemonset/"$PREPULL_DAEMONSET" -n "$NAMESPACE" --timeout=600s
+      kubectl delete daemonset "$PREPULL_DAEMONSET" -n "$NAMESPACE"
+
+      kubectl patch configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" --type merge \
+        -p "{\"data\":{\"prepulled_image\":\"${current_image}\"}}"
+    fi
+
+    for template_dir in coder-templates/*/; do
+      template_name=$(basename "$template_dir")
+      current_sha=$(git log -1 --format=%H -- "$template_dir")
+      last_sha=$(kubectl get configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" \
+        -o jsonpath="{.data.${template_name}}" 2>/dev/null || true)
+
+      if [ "$current_sha" = "$last_sha" ]; then
+        echo "[$template_name] unchanged since $current_sha, skipping"
+        continue
+      fi
+
+      echo "[$template_name] change detected ($last_sha -> $current_sha), pushing"
+      coder login "$CODER_URL" --token "$CODER_TOKEN"
+      coder templates push "$template_name" -d "$template_dir" --yes
+
+      kubectl patch configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" --type merge \
+        -p "{\"data\":{\"${template_name}\":\"${current_sha}\"}}"
+    done

--- a/apps/coder/templates/template-sync-script.yaml
+++ b/apps/coder/templates/template-sync-script.yaml
@@ -12,10 +12,11 @@ data:
     STATE_CONFIGMAP="coder-template-sync-state"
     NAMESPACE="coder"
     CODER_URL="http://coder.coder.svc.cluster.local"
+    export CODER_URL
     PREPULL_DAEMONSET="coder-template-image-prepull"
 
     WORKDIR=$(mktemp -d)
-    git clone --depth 50 --quiet "$REPO_URL" "$WORKDIR/repo"
+    git clone --quiet "$REPO_URL" "$WORKDIR/repo"
     cd "$WORKDIR/repo"
 
     kubectl get configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" >/dev/null 2>&1 || \
@@ -56,11 +57,13 @@ data:
                   cpu: 10m
                   memory: 16Mi
     EOF
-      kubectl rollout status daemonset/"$PREPULL_DAEMONSET" -n "$NAMESPACE" --timeout=600s
-      kubectl delete daemonset "$PREPULL_DAEMONSET" -n "$NAMESPACE"
-
-      kubectl patch configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" --type merge \
-        -p "{\"data\":{\"prepulled_image\":\"${current_image}\"}}"
+      if kubectl rollout status daemonset/"$PREPULL_DAEMONSET" -n "$NAMESPACE" --timeout=480s; then
+        kubectl patch configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" --type merge \
+          -p "{\"data\":{\"prepulled_image\":\"${current_image}\"}}"
+      else
+        echo "Pre-pull rollout did not complete in time; leaving state unset so the next run retries"
+      fi
+      kubectl delete daemonset "$PREPULL_DAEMONSET" -n "$NAMESPACE" --ignore-not-found
     fi
 
     for template_dir in coder-templates/*/; do
@@ -75,7 +78,6 @@ data:
       fi
 
       echo "[$template_name] change detected ($last_sha -> $current_sha), pushing"
-      coder login "$CODER_URL" --token "$CODER_TOKEN"
       coder templates push "$template_name" -d "$template_dir" --yes
 
       kubectl patch configmap "$STATE_CONFIGMAP" -n "$NAMESPACE" --type merge \

--- a/apps/coder/templates/template-sync-secret.yaml
+++ b/apps/coder/templates/template-sync-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: coder-template-sync-token
+  namespace: coder
+spec:
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: coder-template-sync-token
+  data:
+    - secretKey: token
+      remoteRef:
+        key: coder-template-sync-token


### PR DESCRIPTION
## Summary
- Adds a CronJob (every 15m) that pushes coder-templates/*/ changes to the
  live Coder deployment automatically, running in-cluster to avoid the
  private-ingress reachability problem a GitHub Actions runner would hit
- Pre-pulls a new workspace image on all nodes via a short-lived DaemonSet
  when the pinned image digest changes
- New coder-template-sync ServiceAccount/Role/RoleBinding, scoped to
  configmaps + daemonsets in the coder namespace only

Design spec: docs/superpowers/specs/2026-08-21-coder-template-sync-cronjob-design.md

## Prerequisite (manual, one-time, before this actually syncs anything)
A Coder API token must exist in AWS Secrets Manager under the key
`coder-template-sync-token`:
```
coder tokens create --lifetime 8760h
# store the printed token in AWS Secrets Manager as coder-template-sync-token
```

## Test plan
- [x] helm template renders the new resources correctly (CronJob, ExternalSecret,
      ServiceAccount/Role/RoleBinding), no duplication
- [ ] After merge + the token exists: manually trigger a run
      (`kubectl create job --from=cronjob/coder-template-sync -n coder manual-test`),
      confirm it pushes/skips correctly and updates the state ConfigMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)