### PR TITLE
Pin nix-dev workspace image by digest, track with Renovate

### DIFF
--- a/coder-templates/nix-dev/main.tf
+++ b/coder-templates/nix-dev/main.tf
@@ -132,7 +132,7 @@ resource "kubernetes_pod_v1" "main" {
     # `home-manager switch` inside it).
     init_container {
       name    = "seed-home"
-      image   = "ghcr.io/graytonio/nixos-workspace:latest"
+      image   = "ghcr.io/graytonio/nixos-workspace:latest@sha256:8a90bbb1ec92be3720b1d9cceffbbea1862d90099548fe9cb365c6b27a98b168"
       command = ["sh", "-c", "if [ ! -e /mnt/persistent-home/.nix-profile ]; then cp -a /home/coder/. /mnt/persistent-home/; fi"]
 
       volume_mount {
@@ -143,7 +143,7 @@ resource "kubernetes_pod_v1" "main" {
 
     container {
       name    = "dev"
-      image   = "ghcr.io/graytonio/nixos-workspace:latest"
+      image   = "ghcr.io/graytonio/nixos-workspace:latest@sha256:8a90bbb1ec92be3720b1d9cceffbbea1862d90099548fe9cb365c6b27a98b168"
       command = ["sh", "-c", local.agent_start_script]
 
       env {

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,15 @@
         "repository: (?<depName>[^\\n\\[]+)\\n\\s+tag: (?<currentValue>[^\\n\\[]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track ghcr.io/graytonio/nixos-workspace:latest digest in the nix-dev Coder workspace template",
+      "fileMatch": ["^coder-templates/nix-dev/main\\.tf$"],
+      "matchStrings": [
+        "image\\s*=\\s*\"(?<depName>ghcr\\.io/graytonio/nixos-workspace):(?<currentValue>latest)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- coder-templates/nix-dev/main.tf now pins ghcr.io/graytonio/nixos-workspace
  by digest instead of floating :latest -- Docker ignores the tag once a
  digest is present (identical pull behavior), but keeping the tag lets
  Renovate know which stream to keep polling
- renovate.json: new customManagers entry tracks that digest, same shape as
  the existing values.yaml image-tag manager

Design spec: docs/superpowers/specs/2026-08-21-coder-template-sync-cronjob-design.md

## Test plan
- [x] terraform validate passes
- [x] Renovate regex confirmed to actually match the new main.tf line (verified
      the exact depName/currentValue/currentDigest captures locally)
- [ ] Watch for a real Renovate PR after the next nixos-config image publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)