### PR TITLE
Install coder CLI in template-sync job, fix hostname resolution

### DIFF
--- a/apps/coder/templates/template-sync-cronjob.yaml
+++ b/apps/coder/templates/template-sync-cronjob.yaml
@@ -66,6 +66,17 @@ spec:
         spec:
           serviceAccountName: coder-template-sync
           restartPolicy: Never
+          # The coder CLI's own install.sh always downloads the binary from
+          # the server's configured public CODER_ACCESS_URL, regardless of
+          # which URL install.sh itself was fetched from -- confirmed
+          # empirically (fetching install.sh via the internal Service URL
+          # still produced a script with ORIGIN="https://coder.graytonward.com"
+          # baked in). Same DNS gap as the workspace agent's own bootstrap,
+          # same fix: route that hostname to Traefik's private ingress
+          # ClusterIP directly, so it resolves from inside this pod.
+          hostAliases:
+            - ip: "10.43.33.82"
+              hostnames: ["coder.graytonward.com"]
           containers:
             - name: sync
               image: alpine/k8s:1.36.2

--- a/apps/coder/templates/template-sync-script.yaml
+++ b/apps/coder/templates/template-sync-script.yaml
@@ -18,6 +18,15 @@ data:
     ROTATE_THRESHOLD_SECONDS=$((24 * 3600))
     TOKEN_LIFETIME_SECONDS=$((7 * 24 * 3600))
 
+    # alpine/k8s bundles kubectl/git/curl but not the coder CLI itself --
+    # install it fresh each run (confirmed empirically: "coder: not found"
+    # on a real run without this). The pod's hostAliases entry (see
+    # template-sync-cronjob.yaml) is what lets this curl call actually
+    # resolve the hardcoded public hostname install.sh downloads from.
+    if ! command -v coder >/dev/null 2>&1; then
+      curl -fsSL "$CODER_URL/install.sh" | sh
+    fi
+
     # This secret is self-managed, not AWS/ExternalSecret-backed: Coder API
     # tokens here are capped at a 7-day server-enforced max lifetime, and an
     # ExternalSecret's periodic refresh from AWS would just overwrite this


### PR DESCRIPTION
## Summary
- A real manual test of the template-sync CronJob failed with "coder: not
  found" -- alpine/k8s doesn't bundle the coder CLI, an unverified assumption
  in the original design
- Added a one-time-per-run install via the CLI's own install.sh
- That script always downloads the binary from the server's public
  CODER_ACCESS_URL regardless of how install.sh itself was fetched -- same
  DNS gap already solved for workspace agents. Added the same hostAliases
  fix to the CronJob's pod spec (Traefik private ingress ClusterIP)

Verified end-to-end against a live throwaway pod before rolling into the
actual manifests.

## Test plan
- [x] YAML parses, sync.sh passes `sh -n`, chart renders cleanly, hostAliases
      present in rendered output
- [x] Verified against a live pod with hostAliases: install.sh + binary
      download + `coder version` all succeed
- [ ] Re-run the manual CronJob test end-to-end (doing this next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)